### PR TITLE
Faster retry

### DIFF
--- a/services/gunDB/contact-api/utils/index.js
+++ b/services/gunDB/contact-api/utils/index.js
@@ -72,6 +72,29 @@ const timeout5 = promise => {
 
 /**
  * @template T
+ * @param {Promise<T>} promise
+ * @returns {Promise<T>}
+ */
+const timeout2 = promise => {
+  /** @type {NodeJS.Timeout} */
+  // @ts-ignore
+  let timeoutID
+  return Promise.race([
+    promise.then(v => {
+      clearTimeout(timeoutID)
+      return v
+    }),
+
+    new Promise((_, rej) => {
+      timeoutID = setTimeout(() => {
+        rej(new Error(Constants.ErrorCode.TIMEOUT_ERR))
+      }, 2000)
+    })
+  ])
+}
+
+/**
+ * @template T
  * @param {(gun: GUNNode, user: UserGUNNode) => Promise<T>} promGen The function
  * receives the most recent gun and user instances.
  * @param {((resolvedValue: unknown) => boolean)=} shouldRetry
@@ -330,5 +353,6 @@ module.exports = {
   mySecret,
   promisifyGunNode: require('./promisifygun'),
   timeout5,
+  timeout2,
   isNodeOnline
 }

--- a/services/gunDB/contact-api/utils/index.js
+++ b/services/gunDB/contact-api/utils/index.js
@@ -88,7 +88,7 @@ const tryAndWait = async (promGen, shouldRetry = () => false) => {
   let resolvedValue
 
   try {
-    resolvedValue = await timeout10(
+    resolvedValue = await timeout5(
       promGen(
         require('../../Mediator/index').getGun(),
         require('../../Mediator/index').getUser()

--- a/services/gunDB/contact-api/utils/index.js
+++ b/services/gunDB/contact-api/utils/index.js
@@ -111,7 +111,7 @@ const tryAndWait = async (promGen, shouldRetry = () => false) => {
   let resolvedValue
 
   try {
-    resolvedValue = await timeout5(
+    resolvedValue = await timeout2(
       promGen(
         require('../../Mediator/index').getGun(),
         require('../../Mediator/index').getUser()

--- a/services/gunDB/contact-api/utils/index.js
+++ b/services/gunDB/contact-api/utils/index.js
@@ -116,6 +116,36 @@ const tryAndWait = async (promGen, shouldRetry = () => false) => {
       ` args: ${promGen.toString()} -- ${shouldRetry.toString()}`
   )
 
+  await delay(200)
+
+  try {
+    resolvedValue = await timeout5(
+      promGen(
+        require('../../Mediator/index').getGun(),
+        require('../../Mediator/index').getUser()
+      )
+    )
+
+    if (shouldRetry(resolvedValue)) {
+      logger.info(
+        'force retrying' +
+          ` args: ${promGen.toString()} -- ${shouldRetry.toString()} \n resolvedValue: ${resolvedValue}, type: ${typeof resolvedValue}`
+      )
+    } else {
+      return resolvedValue
+    }
+  } catch (e) {
+    logger.error(e)
+    if (e.message === 'NOT_AUTH') {
+      throw e
+    }
+  }
+
+  logger.info(
+    `\n retrying \n` +
+      ` args: ${promGen.toString()} -- ${shouldRetry.toString()}`
+  )
+
   await delay(3000)
 
   try {


### PR DESCRIPTION
Gun bugs were it took longer than maybe 2 seconds tops to fetch data are no longer present. Replaced by either failfast (`undefined`) errors or hangs.

So this PR reduces the timeout of the first try from 10 to 2 seconds in case it's a hang, not worth the 10 seconds wait to throw. All other tries will have 5 second timeouts.

Added a new retry right after the first one but only 200ms apart, as a lot of failfast fetches only need a quick inmediate retry. Saves 3 whole seconds in a lot of situations.