### PR TITLE
Trusted keys bug fixes

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -861,6 +861,9 @@ module.exports = async (
       // Register user after verifying wallet password
       const publicKey = await GunDB.register(alias, password)
 
+      const trustedKeys = await Storage.get('trustedPKs')
+      await Storage.setItem('trustedPKs', [...(trustedKeys || []), publicKey])
+
       // Generate Access Token
       const token = await auth.generateToken()
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -522,17 +522,22 @@ module.exports = async (
           trustedKey => trustedKey === publicKey
         )
         const walletUnlocked = health.LNDStatus.walletStatus === 'unlocked'
+        const { authorization = '' } = req.headers
 
         if (!walletUnlocked) {
-          const unlockedWallet = await unlockWallet(password)
+          await unlockWallet(password)
+        }
 
-          if (!isKeyTrusted && unlockedWallet.field !== 'walletUnlocker') {
-            await Storage.set('trustedPKs', [...trustedKeys, publicKey])
-          }
+        if (walletUnlocked && !authorization && !isKeyTrusted) {
+          res.status(401).json({
+            field: 'alias',
+            errorMessage: 'Invalid alias/password combination',
+            success: false
+          })
+          return
         }
 
         if (walletUnlocked && !isKeyTrusted) {
-          const { authorization = '' } = req.headers
           const validatedToken = await validateToken(
             authorization.replace('Bearer ', '')
           )
@@ -545,6 +550,10 @@ module.exports = async (
             })
             return
           }
+        }
+
+        if (!isKeyTrusted) {
+          await Storage.set('trustedPKs', [...(trustedKeys || []), publicKey])
         }
 
         // Send an event to update lightning's status


### PR DESCRIPTION
- Fixed trusted keys functionality to trust public keys that were logged into using an Authorization token
- Added so public keys are trusted if you're registering for alias with an existing wallet
- Fixed "undefined" log