### PR TITLE
Migrated JWT secrets over to new Storage system

### DIFF
--- a/services/auth/auth.js
+++ b/services/auth/auth.js
@@ -7,90 +7,32 @@ const uuidv1 = require('uuid/v1')
 const jsonfile = require('jsonfile')
 const path = require('path')
 const logger = require('winston')
+const Storage = require('node-persist')
 const FS = require('../../utils/fs')
 
 const rootFolder = process.resourcesPath || __dirname
 const secretsFilePath = path.resolve(rootFolder, 'secrets.json')
 
 class Auth {
-  verifySecretsFile = async () => {
-    try {
-      const fileExists = await FS.access(secretsFilePath)
+  readSecrets = async () => {
+    const secrets = await Storage.get('auth/secrets')
 
-      if (!fileExists) {
-        return { exists: false }
-      }
-
-      const secretsFile = await FS.readFile(secretsFilePath, {
-        encoding: 'utf8'
-      })
-
-      // Check if secrets file has valid JSON
-      JSON.parse(secretsFile)
-
-      return { exists: true, parsable: true }
-    } catch (err) {
-      logger.error(err)
-      return { exists: true, parsable: false }
+    if (secrets) {
+      return secrets
     }
+
+    const newSecrets = await Storage.set('auth/secrets', {})
+
+    return newSecrets
   }
-
-  initSecretsFile = async () => {
-    const { exists, parsable } = await this.verifySecretsFile()
-
-    if (exists && parsable) {
-      // logger.info('Secrets file exists!')
-      return true
-    }
-
-    if (exists && !parsable) {
-      await FS.unlink(secretsFilePath)
-    }
-
-    await FS.writeFile(secretsFilePath, '{}')
-
-    logger.info('New secrets file generated!')
-
-    return true
-  }
-
-  readSecrets = () =>
-    new Promise((resolve, reject) => {
-      this.initSecretsFile()
-        .then(() => {
-          jsonfile.readFile(secretsFilePath, (err, allSecrets) => {
-            if (err) {
-              logger.error('readSecrets err', err)
-              reject('Problem reading secrets file')
-            } else {
-              resolve(allSecrets)
-            }
-          })
-        })
-        .catch(reject)
-    })
 
   async writeSecrets(key, value) {
-    await this.initSecretsFile()
     const allSecrets = await this.readSecrets()
-    return new Promise((resolve, reject) => {
-      allSecrets[key] = value
-      logger.info('Writing new secret:', secretsFilePath)
-      jsonfile.writeFile(
-        secretsFilePath,
-        allSecrets,
-        { spaces: 2, EOL: '\r\n' },
-        err => {
-          if (err) {
-            logger.error('writeSecrets err', err)
-            reject(err)
-          } else {
-            logger.info('New secret saved!')
-            resolve(true)
-          }
-        }
-      )
+    const newSecrets = await Storage.set('auth/secrets', {
+      ...allSecrets,
+      [key]: value
     })
+    return newSecrets
   }
 
   async generateToken() {
@@ -111,7 +53,6 @@ class Auth {
 
   async validateToken(token) {
     try {
-      await this.initSecretsFile()
       const key = jwt.decode(token).data.timestamp
       const secrets = await this.readSecrets()
       const secret = secrets[key]

--- a/src/routes.js
+++ b/src/routes.js
@@ -2767,8 +2767,4 @@ module.exports = async (
       data: isAuthenticated()
     })
   })
-  /**
-   * Return app so that it can be used by express.
-   */
-  // return app;
 }


### PR DESCRIPTION
The API is no longer using the secrets.json file now (makes file permission handling easier on the Wizard side) and improved secrets storage performance as well